### PR TITLE
[INFRA-2825] Set SETUPTOOLS_USE_DISTUTILS=stdlib env var

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -244,6 +244,7 @@ def _pex_binary_impl(ctx):
             # TODO allow overriding PATH
             "PATH": "/bin:/usr/bin:/usr/local/bin",
             "PEX_VERBOSE": str(ctx.attr.verbosity),
+            "SETUPTOOLS_USE_DISTUTILS": "stdlib",
         },
         arguments = arguments,
     )


### PR DESCRIPTION
* pex_binary rule is not respecting --action_env. So, direcly set the env var in the source
* setuptools v60.0.0 is causing breaking changes and setting the above env var is needed to avoid build issues